### PR TITLE
ECS-41 - Fix `RegistrationComponent`

### DIFF
--- a/src/app/_store/effects/auth.effects.ts
+++ b/src/app/_store/effects/auth.effects.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
@@ -37,7 +37,6 @@ export class AuthEffects {
           return this.authService.login(loginData).pipe(
             map(({ token, roles }) => {
               if (!token) {
-                console.log('Login failure');
                 return AuthActions.loginFailure({ errorMessage: 'JWT error' });
               }
               return AuthActions.authSuccess({
@@ -47,12 +46,7 @@ export class AuthEffects {
               });
             }),
             catchError((error: HttpErrorResponse) => {
-              const errorMessage =
-                error.status === HttpStatusCode.Unauthorized
-                  ? 'Wrong username or password'
-                  : 'An unexpected error occurred';
-
-              console.log('Login failure');
+              const errorMessage = error.error.message;
               return of(AuthActions.loginFailure({ errorMessage }));
             }),
           );
@@ -70,7 +64,6 @@ export class AuthEffects {
           return this.authService.socialLogin(loginData).pipe(
             map(({ token, roles }) => {
               if (!token) {
-                console.log('social login failure');
                 return AuthActions.socialLoginFailure({
                   errorMessage: 'JWT error',
                 });
@@ -82,12 +75,7 @@ export class AuthEffects {
               });
             }),
             catchError((error: HttpErrorResponse) => {
-              const errorMessage =
-                error.status === HttpStatusCode.Unauthorized
-                  ? 'Wrong username or password'
-                  : 'An unexpected error occurred';
-
-              console.log('dispatching socialLoginFailure');
+              const errorMessage = error.error.message;
               return of(AuthActions.socialLoginFailure({ errorMessage }));
             }),
           );
@@ -102,7 +90,6 @@ export class AuthEffects {
       return this.actions$.pipe(
         ofType(AuthActions.logout),
         tap(() => {
-          console.log('Logging out');
           localStorage.removeItem('token');
           localStorage.removeItem('state');
           this.router.navigateByUrl('/account/login');
@@ -122,10 +109,7 @@ export class AuthEffects {
               return AuthActions.initProfileSuccess({ user });
             }),
             catchError((error) => {
-              const errorMessage = error
-                ? error[0]
-                : `${AuthActions.initProfile.type} Error while updating user`;
-              console.log('Init profile failure:', errorMessage);
+              const errorMessage = error.error.message;
               return of(AuthActions.initProfileFailure({ errorMessage }));
             }),
           );
@@ -145,10 +129,7 @@ export class AuthEffects {
               return AuthActions.initRolesSuccess({ roles });
             }),
             catchError((error) => {
-              const errorMessage = error
-                ? error[0]
-                : `${AuthActions.initRoles.type} Error while updating user`;
-              console.log('Init roles failure:', errorMessage);
+              const errorMessage = error.error.message;
               return of(AuthActions.initRolesFailure({ errorMessage }));
             }),
           );
@@ -168,10 +149,7 @@ export class AuthEffects {
               return AuthActions.updateUserSuccess({ user: authBlob });
             }),
             catchError((error) => {
-              const errorMessage = error
-                ? error[0]
-                : `${AuthActions.updateUser.type} Error while updating user`;
-              console.log('Update user failure:', errorMessage);
+              const errorMessage = error.error.message;
               return of(AuthActions.updateUserFailure({ errorMessage }));
             }),
           );
@@ -189,7 +167,6 @@ export class AuthEffects {
           return this.authService.register(registerData).pipe(
             map(({ token, roles }) => {
               if (!token) {
-                console.log('register failure');
                 return AuthActions.registerFailure({
                   errorMessage: 'JWT error ',
                 });
@@ -198,10 +175,7 @@ export class AuthEffects {
               return AuthActions.authSuccess({ token, roles });
             }),
             catchError((error) => {
-              const errorMessage = error
-                ? `${AuthActions.register.type} ${error[0]}`
-                : `${AuthActions.register.type} Error while registering`;
-              console.log('Register failure:', errorMessage);
+              const errorMessage = error.error.message;
               return of(AuthActions.registerFailure({ errorMessage }));
             }),
           );

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -48,12 +48,9 @@
           }
         </mat-form-field>
       </div>
-      <div *ngIf="submitted && f['password'].errors" class="invalid-feedback">
-        <div *ngIf="f['password'].errors['required']">Password is required</div>
-      </div>
-      <p *ngIf="errorMessage$ | ngrxPush as msg" class="message-alert-error">
+      <mat-error *ngIf="errorMessage$ | ngrxPush as msg">
         {{ msg }}
-      </p>
+      </mat-error>
       <button mat-stroked-button [disabled]="loading">Login</button>
       <a mat-stroked-button routerLink="../register" class="register-button"
         >Register</a

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -54,7 +54,7 @@
             [formControl]="passwordFormControl"
             [ngClass]="{ 'is-invalid': submitted && f['password'].errors }"
             matTooltip="Please choose a password with at least total 8 characters, 1 lowercase and 1 uppercase character, 1 special character and 1 digit"
-            matTooltipPosition="after"
+            matTooltipPosition="above"
           />
           <button
             mat-icon-button
@@ -64,6 +64,8 @@
             (click)="clickEvent($event)"
             [attr.aria-label]="'Hide password'"
             [attr.aria-pressed]="hide()"
+            matTooltip="Show or hide password"
+            matTooltipPosition="before"
           >
             <mat-icon>{{ hide() ? "visibility_off" : "visibility" }}</mat-icon>
           </button>
@@ -71,28 +73,20 @@
             passwordFormControl.hasError("pattern") &&
             !passwordFormControl.hasError("required")
           ) {
-            <mat-error
-              >Please choose a password with
-              <strong
-                >at least 1 lowercase, 1 uppercase, 1 special and 8 total
-                characters, and at least 1 digit</strong
-              ></mat-error
-            >
+            <mat-error>
+              Please choose a password with at least 1 lowercase, 1 uppercase, 1
+              special and 8 total characters, and at least 1 digit.
+            </mat-error>
           }
           @if (passwordFormControl.hasError("required")) {
             <mat-error>Password is <strong>required</strong></mat-error>
           }
         </mat-form-field>
       </div>
-      <div *ngIf="submitted && f['password'].errors" class="invalid-feedback">
-        <div *ngIf="f['password'].errors['required']">Password is required</div>
-      </div>
-      <p *ngIf="errorMessage$ | ngrxPush as msg" class="message-alert-error">
+      <mat-error *ngIf="errorMessage$ | ngrxPush as msg">
         {{ msg }}
-      </p>
-      <button mat-stroked-button [disabled]="loading || form.errors">
-        Register
-      </button>
+      </mat-error>
+      <button mat-stroked-button [disabled]="loading">Register</button>
       <a mat-stroked-button routerLink="../login" class="cancel-button"
         >Cancel</a
       >

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -1,5 +1,5 @@
 import { NgClass, NgIf } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -21,6 +21,7 @@ import { Store } from '@ngrx/store';
 import { register } from '../../_store/actions/auth.actions';
 import { State, selectAuthErrorMessage } from '../../_store';
 import { AuthPayload, strongPasswordPattern } from '../../_types';
+import { distinctUntilChanged, tap } from 'rxjs';
 
 @Component({
   imports: [
@@ -41,7 +42,7 @@ import { AuthPayload, strongPasswordPattern } from '../../_types';
   styleUrl: './register.component.scss',
   standalone: true,
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
   private readonly store$ = inject(Store<State>);
   readonly errorMessage$ = this.store$.select(selectAuthErrorMessage);
 
@@ -62,7 +63,6 @@ export class RegisterComponent {
   ]);
   passwordFormControl = new FormControl('', [
     Validators.required,
-    Validators.minLength(8),
     Validators.pattern(strongPasswordPattern),
   ]);
 
@@ -72,6 +72,18 @@ export class RegisterComponent {
       email: this.emailFormControl,
       password: this.passwordFormControl,
     });
+  }
+
+  ngOnInit() {
+    this.errorMessage$
+      .pipe(
+        distinctUntilChanged(),
+        tap(() => {
+          this.loading = false;
+          this.submitted = false;
+        }),
+      )
+      .subscribe();
   }
 
   get f() {


### PR DESCRIPTION
- Ensure no bad requests are made from RegistrationComponent by enforcing a password pattern validator on the respective form control.
- Better integrate `<mat-error>` and backend error messages into user feedback
- Fix submit button being disabled until reload when an errors occurs
- Apply the same error feedback changes to `LoginComponent`
- Update `AuthEffects` to correctly catch backend error messages