### PR TITLE
ECS-7- Further implement image upload

### DIFF
--- a/src/app/_services/images.service.ts
+++ b/src/app/_services/images.service.ts
@@ -17,7 +17,13 @@ export class ImagesService {
     return this.http.get<Image[]>(`${this.apiUrl}/user`);
   }
 
-  handleImageUpload(formData: FormData): Observable<Image> {
-    return this.http.post<Image>(`${this.apiUrl}/upload`, formData);
+  handleImageUpload(
+    formData: FormData,
+    tournamentId: number,
+  ): Observable<{ url: string }> {
+    return this.http.post<{ url: string }>(
+      `${this.apiUrl}/upload/checkin/${tournamentId}`,
+      formData,
+    );
   }
 }

--- a/src/app/_types/image.interface.ts
+++ b/src/app/_types/image.interface.ts
@@ -6,8 +6,6 @@ export enum ImageType {
 export interface Image {
   id: number;
   url: string;
-  draftPlayerId: number;
-  imageType: ImageType;
 }
 
 export enum ImageStatus {

--- a/src/app/tournaments/admin/create-tournament/create-tournament.component.ts
+++ b/src/app/tournaments/admin/create-tournament/create-tournament.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import {
   FormBuilder,
+  FormControl,
   FormGroup,
   ReactiveFormsModule,
   Validators,
@@ -30,6 +31,7 @@ import { EnrollmentsService, TournamentsService } from '../../../_services';
 import { selectAllUsers, State } from '../../../_store';
 import { initializeAvailableUsersForTournament } from '../../../_store/actions/users.actions';
 import { initializeEnrollments } from '../../../_store/actions/enrollments.actions';
+import { User } from '../../../_types';
 
 @Component({
   selector: 'app-create-tournament',
@@ -57,18 +59,28 @@ export class CreateTournamentComponent implements OnInit {
 
   readonly availableUsers$ = this.store$.select(selectAllUsers);
 
-  tournamentForm = this.formBuilder.group({
-    name: ['', Validators.required],
-    public: [false, Validators.required],
-    league: [false, Validators.required],
-    playerCapacity: [
-      0,
-      [Validators.required, Validators.pattern(/[0-9]{1,2}/)],
-    ],
-    description: ['', Validators.required],
+  tournamentNameFormControl = new FormControl('', [
+    Validators.required,
+    Validators.minLength(4),
+  ]);
+  publicFormControl = new FormControl<boolean>({
+    value: false,
+    disabled: false,
   });
+  leagueFormControl = new FormControl<boolean>({
+    value: false,
+    disabled: true,
+  });
+  playerCapacityFormControl = new FormControl<number>(0, [
+    Validators.required,
+    Validators.pattern(/[0-9]{1,2}/),
+  ]);
+  descriptionFormControl = new FormControl<string>('', [Validators.required]);
 
-  enrollForm!: FormGroup;
+  usersFormControl = new FormControl<User[]>([]);
+
+  tournamentForm: FormGroup;
+  enrollForm: FormGroup;
 
   loading = false;
   submitted = false;
@@ -84,8 +96,16 @@ export class CreateTournamentComponent implements OnInit {
     private readonly enrollmentService: EnrollmentsService,
     private readonly route: ActivatedRoute,
   ) {
+    this.tournamentForm = this.formBuilder.group({
+      name: this.tournamentNameFormControl,
+      public: this.publicFormControl,
+      league: this.leagueFormControl,
+      playerCapacity: this.playerCapacityFormControl,
+      description: this.descriptionFormControl,
+    });
+
     this.enrollForm = this.formBuilder.group({
-      users: [[]],
+      users: this.usersFormControl,
     });
   }
 
@@ -101,9 +121,6 @@ export class CreateTournamentComponent implements OnInit {
       );
     }
 
-    this.enrollForm.setValue({
-      users: [],
-    });
     setTimeout(() => {
       this.stepper.next();
     }, 1);

--- a/src/app/tournaments/tournament-dashboard/draft-panel/draft-panel.component.html
+++ b/src/app/tournaments/tournament-dashboard/draft-panel/draft-panel.component.html
@@ -15,7 +15,7 @@
   </mat-card-header>
   <mat-card-content>
     <ng-container *ngIf="draft$ | ngrxPush; else noDraft">
-      <app-my-pool />
+      <app-my-pool [tournamentId]="tournamentId()" />
       <app-match-panel />
     </ng-container>
     <ng-template #noDraft>

--- a/src/app/tournaments/tournament-dashboard/draft-panel/draft-panel.component.ts
+++ b/src/app/tournaments/tournament-dashboard/draft-panel/draft-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { RouterLink } from '@angular/router';
@@ -24,7 +24,8 @@ import { MyPoolComponent } from '../pool/my-pool/my-pool.component';
   styleUrl: './draft-panel.component.scss',
 })
 export class DraftPanelComponent {
-  private readonly store$ = inject(Store<State>);
+  tournamentId = input.required<number>();
 
+  private readonly store$ = inject(Store<State>);
   readonly draft$ = this.store$.select(selectCurrentDraft);
 }

--- a/src/app/tournaments/tournament-dashboard/pool/manage-pool/manage-pool.component.html
+++ b/src/app/tournaments/tournament-dashboard/pool/manage-pool/manage-pool.component.html
@@ -1,18 +1,7 @@
-<mat-list class="image-list">
-  @defer {
-  <li *ngFor="let image of images$ | ngrxPush; index as i">
-    <img
-      src="{{ imageUrl }}{{ image.url }}"
-      alt="User uploaded image"
-      class="img-fluid img-thumbnail mt-4 mb-2"
-      style="max-height: 150px; max-width: 150px"
-    />
-  </li>
-  }
-</mat-list>
 <input
   type="file"
   class="file-input"
+  accept="image/jpeg"
   (change)="onFileSelected($event)"
   #fileUpload
 />

--- a/src/app/tournaments/tournament-dashboard/pool/manage-pool/manage-pool.component.ts
+++ b/src/app/tournaments/tournament-dashboard/pool/manage-pool/manage-pool.component.ts
@@ -1,32 +1,34 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
-import { MatListModule } from '@angular/material/list';
-import { PushPipe } from '@ngrx/component';
+import { Component, inject, input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
 
 import { dev } from '../../../../../environments/environment';
 import { ImagesService } from '../../../../_services';
-import { selectAllImages, State } from '../../../../_store';
-import { Image } from '../../../../_types';
+import { State } from '../../../../_store';
+import { initializePlayerImages } from '../../../../_store/actions/images.actions';
 
 @Component({
   selector: 'app-manage-pool',
   standalone: true,
-  imports: [CommonModule, MatListModule, PushPipe],
+  imports: [CommonModule],
   templateUrl: './manage-pool.component.html',
   styleUrl: './manage-pool.component.scss',
 })
-export class ManagePoolComponent {
+export class ManagePoolComponent implements OnInit {
+  tournamentId = input.required<number>();
+
   loading = false;
   submitted = false;
   imgFile: File | null = null;
   readonly imageUrl = dev.userUploadUrl;
 
   private readonly store$ = inject(Store<State>);
-  readonly images$: Observable<Image[]> = this.store$.select(selectAllImages);
 
   constructor(private readonly imageService: ImagesService) {}
+
+  ngOnInit() {
+    this.store$.dispatch(initializePlayerImages());
+  }
 
   onFileSelected(event: any) {
     const file: File = event.target.files[0];
@@ -48,7 +50,9 @@ export class ManagePoolComponent {
 
     const formData = new FormData();
     formData.append('file', this.imgFile);
-    this.imageService.handleImageUpload(formData).subscribe();
+    this.imageService
+      .handleImageUpload(formData, this.tournamentId())
+      .subscribe();
     this.imgFile = null;
     this.loading = false;
   }

--- a/src/app/tournaments/tournament-dashboard/pool/my-pool/my-pool.component.html
+++ b/src/app/tournaments/tournament-dashboard/pool/my-pool/my-pool.component.html
@@ -16,5 +16,8 @@
       <mat-panel-description>I am not checked out.</mat-panel-description>
     </ng-template>
   </mat-expansion-panel-header>
-  <app-manage-pool />
+  <app-manage-pool [tournamentId]="tournamentId()" />
+  <section class="image-list">
+    <img *ngFor="let image of images$ | ngrxPush" src="{{ image.url }}" />
+  </section>
 </mat-expansion-panel>

--- a/src/app/tournaments/tournament-dashboard/pool/my-pool/my-pool.component.ts
+++ b/src/app/tournaments/tournament-dashboard/pool/my-pool/my-pool.component.ts
@@ -1,25 +1,40 @@
-import { NgIf } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { Component, inject, input, OnInit } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { PushPipe } from '@ngrx/component';
 import { Store } from '@ngrx/store';
-import { Observable } from 'rxjs';
+import { distinctUntilChanged, map, Observable } from 'rxjs';
 
-import { selectCurrentPoolStatus, State } from '../../../../_store';
-import { PoolStatus } from '../../../../_types';
+import {
+  selectAllImages,
+  selectCurrentPoolStatus,
+  State,
+} from '../../../../_store';
+import { Image, PoolStatus } from '../../../../_types';
 import { ManagePoolComponent } from '../manage-pool/manage-pool.component';
 
 @Component({
   selector: 'app-my-pool',
   standalone: true,
-  imports: [ManagePoolComponent, MatExpansionModule, NgIf, PushPipe],
+  imports: [ManagePoolComponent, MatExpansionModule, NgFor, NgIf, PushPipe],
   templateUrl: './my-pool.component.html',
   styleUrl: './my-pool.component.scss',
 })
-export class MyPoolComponent {
-  private readonly store$ = inject(Store<State>);
+export class MyPoolComponent implements OnInit {
+  tournamentId = input.required<number>();
 
+  private readonly store$ = inject(Store<State>);
+  readonly images$: Observable<Image[]> = this.store$.select(selectAllImages);
   readonly poolStatus$: Observable<PoolStatus | null> = this.store$.select(
     selectCurrentPoolStatus,
   );
+
+  ngOnInit() {
+    this.images$
+      .pipe(
+        distinctUntilChanged(),
+        map((images) => console.log(JSON.stringify(images))),
+      )
+      .subscribe();
+  }
 }

--- a/src/app/tournaments/tournament-dashboard/tournament-dashboard.component.html
+++ b/src/app/tournaments/tournament-dashboard/tournament-dashboard.component.html
@@ -6,7 +6,7 @@
       <mat-tab-group animationDuration="0ms">
         <mat-tab label="Player View">
           <ng-container *ngIf="enrollment$ | ngrxPush as enrollment">
-            <app-draft-panel></app-draft-panel>
+            <app-draft-panel [tournamentId]="tournamentId()"></app-draft-panel>
             <app-tournament-standings [tournamentId]="tournament.id">
             </app-tournament-standings>
           </ng-container>
@@ -74,7 +74,7 @@
     </ng-container>
     <ng-template #noAdmin>
       <ng-container *ngIf="enrollment$ | ngrxPush as enrollment">
-        <app-draft-panel></app-draft-panel>
+        <app-draft-panel [tournamentId]="tournamentId()"></app-draft-panel>
         <app-tournament-standings [tournamentId]="tournament.id">
         </app-tournament-standings>
       </ng-container>


### PR DESCRIPTION
Make pool components stateful and show images
Changed the frontend `Image` type to only hold a URL and ID. This is because the backend and frontend types have diverged, where the backend holds the internal storage path, which the frontend should not know about and cannot use. Instead, a pre-signed MinIO URL is passed to the frontend to load the images. These expire after 24 hours. Add a `tournamentId` input to pool components that they can pass to the API endpoint.