### PR TITLE
ECS-49 - Improve result reporting queries

### DIFF
--- a/src/app/tournaments/tournament-dashboard/report-result-form/report-result-form.component.html
+++ b/src/app/tournaments/tournament-dashboard/report-result-form/report-result-form.component.html
@@ -1,13 +1,11 @@
 <form [formGroup]="form" *ngIf="form" (ngSubmit)="onSubmit()">
   <div class="form-input player-wins">
-    <label class="form-label"
-      >{{
-        (currentMatch$ | ngrxPush)?.player1?.enrollment?.user?.username
-      }}
-      wins</label
-    >
+    <mat-label>
+      {{ (currentMatch$ | ngrxPush)?.player1?.enrollment?.user?.username }}
+      wins
+    </mat-label>
     <mat-button-toggle-group
-      formControlName="player1Wins"
+      [formControl]="player1WinsFormControl"
       aria-label="Player 1 Wins"
       exclusive
     >
@@ -22,14 +20,12 @@
     </div>
   </div>
   <div class="form-input player-wins">
-    <label class="form-label"
-      >{{
-        (currentMatch$ | ngrxPush)?.player2?.enrollment?.user?.username
-      }}
-      wins</label
-    >
+    <mat-label>
+      {{ (currentMatch$ | ngrxPush)?.player2?.enrollment?.user?.username }}
+      wins
+    </mat-label>
     <mat-button-toggle-group
-      formControlName="player2Wins"
+      [formControl]="player2WinsFormControl"
       aria-label="Player 2 Wins"
       exclusive
     >

--- a/src/app/tournaments/tournament-dashboard/report-result-form/report-result-form.component.ts
+++ b/src/app/tournaments/tournament-dashboard/report-result-form/report-result-form.component.ts
@@ -8,9 +8,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatInputModule } from '@angular/material/input';
 import { PushPipe } from '@ngrx/component';
 import { Store } from '@ngrx/store';
-import { firstValueFrom } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs';
 
 import { matchSumValidator } from '../../../_helpers/match-form.validator';
 import { MatchesService } from '../../../_services';
@@ -19,38 +20,49 @@ import { State, selectCurrentMatch } from '../../../_store';
 @Component({
   selector: 'app-report-result-form',
   standalone: true,
-  imports: [NgIf, PushPipe, MatButtonToggleModule, ReactiveFormsModule],
+  imports: [
+    MatButtonToggleModule,
+    MatInputModule,
+    NgIf,
+    PushPipe,
+    ReactiveFormsModule,
+  ],
   templateUrl: './report-result-form.component.html',
   styleUrl: './report-result-form.component.scss',
 })
 export class ReportResultFormComponent implements OnInit {
+  private readonly store$ = inject(Store<State>);
+  readonly currentMatch$ = this.store$.select(selectCurrentMatch);
+
   form: FormGroup;
   loading = false;
   submitted = false;
 
-  private readonly store$ = inject(Store<State>);
-
-  readonly currentMatch$ = this.store$.select(selectCurrentMatch);
+  matchIdFormControl = new FormControl<number>(0, [
+    Validators.required,
+    Validators.min(0),
+  ]);
+  player1WinsFormControl = new FormControl<number>(0, [
+    Validators.required,
+    Validators.min(0),
+    Validators.max(2),
+  ]);
+  player2WinsFormControl = new FormControl<number>(0, [
+    Validators.required,
+    Validators.min(0),
+    Validators.max(2),
+  ]);
 
   constructor(
     private formBuilder: FormBuilder,
     private readonly matchService: MatchesService,
   ) {
     // Initialize result reporting form
-    // FIXME: move form controls to class members so template can see them
     this.form = this.formBuilder.group(
       {
-        matchId: new FormControl(0, [Validators.required, Validators.min(0)]),
-        player1Wins: new FormControl([
-          Validators.required,
-          Validators.min(0),
-          Validators.max(2),
-        ]),
-        player2Wins: new FormControl([
-          Validators.required,
-          Validators.min(0),
-          Validators.max(2),
-        ]),
+        matchId: this.matchIdFormControl,
+        player1Wins: this.player1WinsFormControl,
+        player2Wins: this.player2WinsFormControl,
       },
       // Ensure total number of games reported is not greater than 3
       { validators: matchSumValidator },
@@ -59,11 +71,16 @@ export class ReportResultFormComponent implements OnInit {
 
   async ngOnInit() {
     // Initial form values
-    // FIXME: ew
-    const matchId = await firstValueFrom(this.currentMatch$);
-    this.form.setValue({
-      matchId,
-    });
+    this.currentMatch$
+      .pipe(
+        distinctUntilChanged(),
+        map((match) => {
+          if (match) {
+            this.form.patchValue({ matchId: match.id });
+          }
+        }),
+      )
+      .subscribe();
   }
 
   get f() {
@@ -79,13 +96,9 @@ export class ReportResultFormComponent implements OnInit {
     }
     this.loading = true;
 
-    // FIXME: double ew
-    await firstValueFrom(
-      this.matchService.reportResult(this.f['matchId'].value, {
-        player1Wins: this.f['player1Wins'].value,
-        player2Wins: this.f['player2Wins'].value,
-      }),
-    );
-    this.loading = false;
+    this.matchService.reportResult(this.f['matchId'].value, {
+      player1Wins: this.f['player1Wins'].value,
+      player2Wins: this.f['player2Wins'].value,
+    });
   }
 }


### PR DESCRIPTION
Change awaits to subscriptions, add independent form controls
- Remove the `await firstValueFrom()` nonsense when reporting or confirming results. Instead, properly subscribe to the API response.
- Move form controls to standalone `FormControl` instances that get selected via `[formControl]` instead of `formControlName` in the HTML.